### PR TITLE
[WIP] Incorporate project guidance into website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUNDLE := bundle
 YARN := yarn
 JS_VENDOR_DIR = js/vendor
 CSS_VENDOR_DIR = css/vendor
-CSS_FONTS_DIR = css/fonts
+CSS_FONTS_DIR = css
 JEKYLL := $(BUNDLE) exec jekyll
 
 PROJECT_DEPS := Gemfile package.json

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Code for San Francisco
 url: http://alpha.codeforsanfrancisco.org
 title: Code for San Francisco
-description: "San Francisco's weekly event to build, share, and learn about civic tech"
+description: "San Francisco's local volunteer civic technology group. We build, share and learn together throughout the year."
 encoding: utf-8
 timezone: America/Los_Angeles
 permalink: pretty

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,9 @@
+<div class="alert alert-warning text-center alert-dismissable" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+<p>
+  <strong>This site is in beta!</strong> <a href="mailto:hello@codeforsanfrancisco.org?subject=Alpha%20Site%20Feedback">Please give us feedback</a> or <a href="https://github.com/{{ site.github}}" >or contribute!</a> <strong>Looking for the old site?</strong> It is up at <a href="http://brigadehub.codeforsanfrancisco.org">brigadehub.codeforsanfrancisco.org</a>
+</p>
+</div>
 <nav class="navbar navbar-inverted navbar-static-top">
   <div class="container">
     <div class="navbar-header">
@@ -20,11 +26,3 @@
     </div>
   </div>
 </nav>
-<div class="alert alert-warning text-center">
-  <p>
-    <strong>This site is in beta!</strong> <a href="mailto:hello@codeforsanfrancisco.org?subject=Alpha%20Site%20Feedback">Please give us feedback</a> or <a href="https://github.com/{{ site.github}}" >or contribute!</a>
-  </p>
-  <p>
-    <strong>Looking for the old site?</strong> It is up at <a href="http://brigadehub.codeforsanfrancisco.org">brigadehub.codeforsanfrancisco.org</a>
-  </p>
-</div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-inverted navbar-static-top">
-  <div class="container-fluid">
+  <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="sr-only">Toggle navigation</span>

--- a/blog.html
+++ b/blog.html
@@ -8,7 +8,7 @@ description: A communal blog with the goal of amplifying more diverse perspectiv
   <i class='fa fa-pencil'></i> Blog
 </h1>
 
-<p>
+<p class="lead">
   A communal blog with the goal of amplifying more diverse perspectives and stories in San Francisco civic tech.
 </p>
 

--- a/events.html
+++ b/events.html
@@ -8,7 +8,7 @@ description: Recent and upcoming hack nights and other Code for San Francisco ev
   <i class='fa fa-calendar-o'></i> Events
 </h1>
 
-<p>
+<p class="lead">
   Past and upcoming events, with links to each event's agenda and any resources. We host Hack Night every Wednesday and
   several larger and special events throughout the year.
 


### PR DESCRIPTION
This is a work in progress (do not merge)

Will include:

- [ ] Changes to the home page to experiment with content and messaging
- [ ] Addition of a project guidelines page
- [ ] Threading of project guidelines into home page and projects landing page
- [ ] Other minor styling changes for consistency

Goal is to get a minimal amount of content and then user test the tweaks with some new members. Likely, v1 will fail, but we can use whatever learning we get to improve it quickly.

Working hypothesis: providing clear, discoverable project guidelines will help members orient to what are the minimum standards for a project at Code for San Francisco
