### PR TITLE
Fix conditional logic for including GA snippet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -104,8 +104,7 @@
   <script src="{{ site.baseurl }}/js/vendor/html5shiv.min.js"></script>
   <script src="{{ site.baseurl }}/js/vendor/respond.min.js"></script>
 <![endif]-->
-
-{% if site.google_analytics and jekyll.environment == 'production' %}
+{% if site.google_analytics and site.environment == 'production' %}
   {% include analytics.html %}
 {% endif %}
 

--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,0 +1,17 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+# Modified from https://gist.github.com/nicolashery/5756478
+module Jekyll
+  class EnvironmentVariablesGenerator < Generator
+    def generate(site)
+      # set by Netlify: https://www.netlify.com/docs/continuous-deployment/
+      site.config['environment'] = case ENV['CONTEXT']
+                                   when 'production'
+                                     'production'
+                                   when 'deploy-preview', 'branch-deploy'
+                                     'staging'
+                                   else
+                                     'development'
+                                   end
+    end
+  end
+end


### PR DESCRIPTION
When we moved to Netlify, jekyll.environment was no longer set. Instead,
read from Netlify's CONTEXT build environment variable to conditionally
set the environment of the site.