### PR TITLE
Use https:// for gravatar links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,10 +34,10 @@ layout: default
             <div class='media-left'>
               {% if author.url %}
                 <a href='{{author.url}}'>
-                  <img class='media-object author-image' src="http://gravatar.com/avatar/{{author.gravatar}}" alt="{{ author.name }}">
+                  <img class='media-object author-image' src="https://gravatar.com/avatar/{{author.gravatar}}" alt="{{ author.name }}">
                 </a>
               {% else %}
-                <img class='media-object author-image' src="http://gravatar.com/avatar/{{author.gravatar}}" alt="{{ author.name }}">
+                <img class='media-object author-image' src="https://gravatar.com/avatar/{{author.gravatar}}" alt="{{ author.name }}">
               {% endif %}
             </div>
             <div class="media-body">

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -82,10 +82,10 @@ layout: default
               {% assign member = site.data.authors[page.project_lead] %}
               {% if member.url %}
                 <a href='{{member.url}}'>
-                  <img class='media-object member-image' src="http://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
+                  <img class='media-object member-image' src="https://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
                 </a>
               {% else %}
-                <img class='media-object member-image' src="http://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
+                <img class='media-object member-image' src="https://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
               {% endif %}
             </td>
           </tr>
@@ -98,10 +98,10 @@ layout: default
                 {% assign member = site.data.authors[member_key] %}
                   {% if member.url %}
                     <a href='{{member.url}}'>
-                      <img class='media-object member-image' src="http://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
+                      <img class='media-object member-image' src="https://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
                     </a>
                   {% else %}
-                    <img class='media-object member-image' src="http://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
+                    <img class='media-object member-image' src="https://gravatar.com/avatar/{{member.gravatar}}" alt="{{ member.name }}">
                   {% endif %}
               {% endfor %}
             </td>

--- a/about/team.html
+++ b/about/team.html
@@ -15,7 +15,7 @@ description: Code for San Francisco organization team.
 <div class='row'>
   {% for member in site.data.team %}
     <div class='col-sm-4'>
-      <img class='img-rounded img-responsive' src="http://gravatar.com/avatar/{{member.gravatar}}" alt="{{ author.name }}">
+      <img class='img-rounded img-responsive' src="https://gravatar.com/avatar/{{member.gravatar}}" alt="{{ author.name }}">
       <h4>
         <ul class="list-unstyled">
           <li>


### PR DESCRIPTION
This way we don't get mixed content warnings when viewing the site with https://.

 I also considered leaving the protocol out so it would default to whatever is currently being used, but production redirects http:// to https://.