### PR TITLE
Removing open data day event

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,37 +10,6 @@ layout: default
   designers, data geeks, and citizen activists who use creative technology to solve civic and social problems.
 </p>
 <div class="row mb-3">
-
-
-   <div class="col-md-6">
-    <ul class="list-group text-center">
-      <li class="list-group-item">
-        <h3>Open Data Day!</h3>
-        Learn, connect and be inspired!
-Groups from around the world will be gathering to show the benefits of open data and encourage the adoption of open data policies in government, business and civil society.
-
-Data Science Working Group will give a workshop on data analysis with R, OpenTransit will let users visualize all Muni transit for one full day as well as investigate stop wait times or other metrics, DataSF will give a workshop on using SF's open data portal and more!
-
-It’ll be a day of learning, experimenting, and exploring what’s possible when companies and governments open their data
-      </li>
-      <li class="list-group-item" title="See Meetup for more info">
-        <strong>When: </strong>Sunday March 3, 9:30am - 5:30pm<br>
-        <small><i class="fa fa-info-circle"></i> See Meetup for more info</small>
-      </li>
-      <li class="list-group-item">
-        <strong>Where:</strong>
-        <a href="https://www.google.com/maps/place/680+Folsom+St+%23145,+San+Francisco,+CA+94107/data=!4m2!3m1!1s0x8085807c3358ae9f:0x1235e4fa0ee400fb?ved=2ahUKEwiewprD88vgAhXpr1QKHYTtCSgQ8gEwAHoECAAQAQ">Microsoft Reactor</a>
-      </li>
-      <li class="list-group-item">
-        <a href="https://www.eventbrite.com/e/code-for-san-francisco-open-data-day-2019-tickets-56291530483?mc_cid=eb08b2049f&mc_eid=3dfc9428bb" class="btn btn-danger">
-          RSVP on EventBrite
-          <i class="fa fa-meetup"></i>
-        </a>
-      </li>
-    </ul>
-  </div>
-
-
   <div class="col-md-6">
     <ul class="list-group text-center">
       <li class="list-group-item">

--- a/index.html
+++ b/index.html
@@ -32,13 +32,13 @@ It’ll be a day of learning, experimenting, and exploring what’s possible whe
         <a href="https://www.google.com/maps/place/680+Folsom+St+%23145,+San+Francisco,+CA+94107/data=!4m2!3m1!1s0x8085807c3358ae9f:0x1235e4fa0ee400fb?ved=2ahUKEwiewprD88vgAhXpr1QKHYTtCSgQ8gEwAHoECAAQAQ">Microsoft Reactor</a>
       </li>
       <li class="list-group-item">
-        <a href="https://www.eventbrite.com/e/code-for-san-francisco-open-data-day-2019-tickets-56291530483?mc_cid=eb08b2049f&amp;mc_eid=3dfc9428bb" class="btn btn-danger">
+        <a href="https://www.eventbrite.com/e/code-for-san-francisco-open-data-day-2019-tickets-56291530483?mc_cid=eb08b2049f&mc_eid=3dfc9428bb" class="btn btn-danger">
           RSVP on EventBrite
           <i class="fa fa-meetup"></i>
         </a>
       </li>
-     </ul>
-  <iframe width="100%" height="400" frameborder="0" style="border:0" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3153.2311016871727!2d-122.4004169842607!3d37.78462347975769!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8085807c4ac95771%3A0x97838fa44b46f66a!2sMicrosoft+Reactor!5e0!3m2!1sen!2sus!4v1550783150941" allowfullscreen=""></iframe></div>
+    </ul>
+  </div>
 
 
   <div class="col-md-6">
@@ -74,9 +74,12 @@ It’ll be a day of learning, experimenting, and exploring what’s possible whe
           <i class="fa fa-envelope"></i>
         </a>
       </li>
-    </ul><iframe width="100%" height="400" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:ChIJ5TaJx2KAhYARCMH_oRu-g50&amp;key=AIzaSyBSdXQPDe62iDqi1Bp9u92gBGDSaeKWhBw" allowfullscreen=""></iframe>
+    </ul>
   </div>
-  
+  <div class="col-md-6">
+    <iframe width="100%" height="450" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:ChIJ5TaJx2KAhYARCMH_oRu-g50&amp;key=AIzaSyBSdXQPDe62iDqi1Bp9u92gBGDSaeKWhBw"
+      allowfullscreen=""></iframe>
+  </div>
 
 </div>
 


### PR DESCRIPTION
Reverting back to before the open data day event was hardcoded on the first page. 