### PR TITLE
Update “Donate” page link

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -14,7 +14,7 @@ description: Support Code for San Francisco!
 
 <div class="text-center">
   <p>
-    <a class="btn btn-primary btn-lg" href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Francisco" role="button">Donate Now!</a>
+    <a class="btn btn-primary btn-lg" href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Francisco&utm_source=CodeforSanFrancisco%20site" role="button">Donate Now!</a>
   </p>
   <p>
     <small>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ